### PR TITLE
SAP-Routerstring translates to invalid cache-file path

### DIFF
--- a/plugins-scripts/Classes/SAP.pm
+++ b/plugins-scripts/Classes/SAP.pm
@@ -163,15 +163,19 @@ sub validate_args {
 sub create_statefile {
   my $self = shift;
   my %params = @_;
-  my $extension = "";
+  my ($extension, $ashost) = "";
   $extension .= $params{name} ? '_'.$params{name} : '';
   $extension =~ s/\//_/g;
   $extension =~ s/\(/_/g;
   $extension =~ s/\)/_/g;
   $extension =~ s/\*/_/g;
   $extension =~ s/\s/_/g;
+  
+  $ashost = $self->opts->ashost;
+  $ashost =~ s/\//_/g;
+  
   return sprintf "%s/%s_%s_%s%s", $self->statefilesdir(),
-      $self->opts->ashost, $self->opts->sysnr, $self->opts->mode, lc $extension;
+      $ashost, $self->opts->sysnr, $self->opts->mode, lc $extension;
 }
 
 sub epoch_to_abap_date {


### PR DESCRIPTION
Problem bei Verwendung des SAP-Routerstrings mit Definition der Pfade für die Cache Datei.

Beispiel:
$ ./check_sap_health.orig --ashost /H/sap-a.wuerth.com/S/3297/H/sap-b.wuerth.com/S/3297/H/sapapp1.other.domain.wuerth.com --sysnr 1 --r3name SID --mode=list-ccms-mtes --name 'SAP CCMS Monitor Templates' --name2 Database
Can't open /var/tmp/check_sap_health.orig//H/sap-a.wuerth.com/S/3297/H/sap-b.wuerth.com/S/3297/H/sapapp1.other.domain.wuerth.com_10_list-ccms-mtes_tree_sap_ccms_monitor_templates_database: No such file or directory at /usr/lib/nagios/plugins/check_sap_health.orig line 3081.
Use of uninitialized value $content in string at /usr/lib/nagios/plugins/check_sap_health.orig line 3083.
UNKNOWN - cannot write status file /var/tmp/check_sap_health.orig//H/sap-a.wuerth.com/S/3297/H/sap-b.wuerth.com/S/3297/H/sapapp1.other.domain.wuerth.com_10_list-ccms-mtes_tree_sap_ccms_monitor_templates_database! check your filesystem (permissions/usage/integrity) and disk devices, Can't use an undefined value as an ARRAY reference at /usr/lib/nagios/plugins/check_sap_health.orig line 3085.