### PR TITLE
Avoid "Use of uninitialized value"

### DIFF
--- a/plugins-scripts/Classes/SAP/Netweaver.pm
+++ b/plugins-scripts/Classes/SAP/Netweaver.pm
@@ -196,7 +196,7 @@ sub create_statefile {
   $extension =~ s/\//_/g;
   $extension =~ s/\|/_/g;
   my $target = "";
-  $target .= $self->opts->ashost.'_'.$self->opts->sysnr if $self->opts->ashost;
+  $target .= $self->opts->ashost.'_'.$self->opts->sysnr if ($self->opts->ashost && $self->opts->sysnr);
   $target .= $self->opts->mshost if $self->opts->mshost;
   $target .= $self->opts->msserv if $self->opts->msserv;
   $target .= $self->opts->r3name if $self->opts->r3name;


### PR DESCRIPTION
Small fix to avoid "Use of uninitialized value in concatenation (.) or string at /usr/lib64/nagios/plugins/check_sap_health_new line 3037."